### PR TITLE
Deleted unused iamFunctions variable.

### DIFF
--- a/ApiGatewayAuthExtension.js
+++ b/ApiGatewayAuthExtension.js
@@ -42,7 +42,6 @@ class ApiGatewayAuthExtension {
 	_compileEvents() {
 		const tmp = this.serverless.service.provider.compiledCloudFormationTemplate;
 		const resources = tmp.Resources;
-		const iamFunctions = this.serverless.service.custom.useApiGatewayIAMAuthForLambdaFunctions;
 
 		this.serverless.service.getAllFunctions().forEach((functionName) => {
 			const functionObject = this.serverless.service.functions[functionName];


### PR DESCRIPTION
I deleted unused iamFunctions variable. I'm using a Serverless 1.10.2
and it was breaking a build - serverless.service.custom is now undefined
(I don't know how it was handled in previous versions of serverless to
be fair).


EDIT: I now see the same change on fix-errors branch made by you. Please merge either of the branches ;)